### PR TITLE
UnitTests.ymlをCIが通るよう修正

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           xcode-version: '14.3.1'
 
-      - uses: futureware-tech/simulator-action@v2
-        with:
-          model: 'iPhone 14'
-          os: 'iOS'
-          os_version: '16.4'
+      # - uses: futureware-tech/simulator-action@v2
+      #   with:
+      #     model: 'iPhone 14'
+      #     os: 'iOS'
+      #     os_version: '16.4'
 
       - name: UnitTests
         run: |

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -22,6 +22,5 @@ jobs:
             -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
             -configuration Debug \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,os=16.4,name=iPhone 14'
-
+            -destination 'platform=iOS Simulator,OS=16.4,name=iPhone 14' \
+            -sdk iphonesimulator

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -12,21 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache
-        uses: actions/cache@v3
+      - uses: maxim-lobanov/setup-xcode@v1
         with:
-          path: "~/Downloads"
-          key: ${{ runner.os }}-runtimes-downloads-16.4        
-      - name: Install Xcodes
-        shell: bash
-        run: |
-          brew install aria2
-          brew tap robotsandpencils/made
-          brew install robotsandpencils/made/xcodes
-          xcodes install --latest
-      - name: Install Simulator
-        shell: bash
-        run: sudo xcodes runtimes install --keep-archive 'iOS 16.4'
+          xcode-version: '14.3.1'
+
+      - uses: muukii/actions-xcode-install-simulator@main
+        with:
+          ios_version: "16.4"
 
       - name: UnitTests
         run: |

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -1,9 +1,9 @@
+
 name: UnitTests
 
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 jobs:
   build:
@@ -14,7 +14,14 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.1.0'
+          xcode-version: '14.3.1'
 
       - name: UnitTests
-        run: xcodebuild test -project UnitTestApp01.xcodeproj -scheme UnitTestApp01 -sdk iphonesimulator -destination 'platform=iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder,name=Any iOS Simulator Device'
+        run: |
+          xcodebuild test \
+            -project UnitTestApp01.xcodeproj \
+            -scheme UnitTestApp01 \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 14,os=16.4'
+

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: UnitTests
         run: |
           xcodebuild test \
-            -project ../UnitTestApp01.xcodeproj \
+            -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
             -destination 'platform=iOS Simulator,name=iPhone 11'
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -16,9 +16,11 @@ jobs:
         with:
           xcode-version: '14.3.1'
 
-      - uses: muukii/actions-xcode-install-simulator@main
+      - uses: futureware-tech/simulator-action@v2
         with:
-          ios_version: "16.4"
+          model: 'iPhone 14'
+          os: 'iOS'
+          os_version: '16.4'
 
       - name: UnitTests
         run: |

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,6 +17,10 @@ jobs:
           xcode-version: '14.1.0'
 
       - name: UnitTests
-        run: xcodebuild test -project ../UnitTestApp01.xcodeproj -scheme UnitTestApp01 -destination 'platform=iOS, name=Any iOS Device'
+        run: |
+          xcodebuild test \
+            -project ../UnitTestApp01.xcodeproj \
+            -scheme UnitTestApp01 \
+            -destination 'platform=iOS Simulator,name=iPhone 11'
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.3.1'
+          xcode-version: '14.2.0'
 
       - uses: muukii/actions-xcode-install-simulator@main
         with:

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -1,4 +1,3 @@
-
 name: UnitTests
 
 on:
@@ -14,21 +13,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.3.1'
-
-      # - uses: futureware-tech/simulator-action@v2
-      #   with:
-      #     model: 'iPhone 14'
-      #     os: 'iOS'
-      #     os_version: '16.4'
+          xcode-version: '14.1.0'
 
       - name: UnitTests
-        run: |
-          xcodebuild test \
-            -project UnitTestApp01.xcodeproj \
-            -scheme UnitTestApp01 \
-            -configuration Debug \
-            -destination 'platform=iOS Simulator,OS=16.4,name=iPhone 14' \
-            -sdk iphonesimulator
-
-
+        run: xcodebuild test -project UnitTestApp01.xcodeproj -scheme UnitTestApp01 -sdk iphonesimulator -destination 'platform=iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder,name=Any iOS Simulator Device'

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,6 +17,6 @@ jobs:
           xcode-version: '14.1.0'
 
       - name: UnitTests
-        run: xcodebuild test -project UnitTestApp01.xcodeproj -scheme UnitTestApp01 -sdk iphonesimulator -destination 'platform=iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder,name=Any iOS Simulator Device'
+        run: xcodebuild test -project UnitTestApp01.xcodeproj -scheme UnitTestApp01 -destination 'platform=iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder,name=Any iOS Simulator Device'
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -18,7 +18,7 @@ jobs:
             -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
             -configuration Debug \
-            -destination 'platform=iOS Simulator, OS=16.4, name=iPhone14' \
+            -destination 'platform=iOS Simulator,OS=16.4,name=iPhone 14' \
             -sdk iphonesimulator
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -12,9 +12,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: muukii/actions-xcode-install-simulator@main
+      - name: Cache
+        uses: actions/cache@v3
         with:
-          ios_version: "16.4"
+          path: "~/Downloads"
+          key: ${{ runner.os }}-runtimes-downloads-16.4        
+      - name: Install Xcodes
+        shell: bash
+        run: |
+          brew install aria2
+          brew tap robotsandpencils/made
+          brew install robotsandpencils/made/xcodes
+          xcodes install --latest
+      - name: Install Simulator
+        shell: bash
+        run: sudo xcodes runtimes install --keep-archive 'iOS 16.4'
 
       - name: UnitTests
         run: |

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.2.0'
+          xcode-version: latest
 
       - uses: muukii/actions-xcode-install-simulator@main
         with:

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -18,7 +18,7 @@ jobs:
             -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
             -configuration Debug \
-            -destination 'platform=iOS Simulator' \
+            -destination 'platform=iOS Simulator, OS=16.4, name=iPhone14' \
             -sdk iphonesimulator
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -3,6 +3,7 @@ name: UnitTests
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,6 +17,6 @@ jobs:
           xcode-version: '14.1.0'
 
       - name: UnitTests
-        run: xcodebuild test -project UnitTestApp01.xcodeproj -scheme UnitTestApp01 -destination 'platform=iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder,name=Any iOS Simulator Device'
+        run: xcodebuild test -project ../UnitTestApp01.xcodeproj -scheme UnitTestApp01 -destination 'platform=iOS, id=dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name=Any iOS Device'
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,6 +17,6 @@ jobs:
           xcode-version: '14.1.0'
 
       - name: UnitTests
-        run: xcodebuild test -project ../UnitTestApp01.xcodeproj -scheme UnitTestApp01 -destination 'platform=iOS, id=dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name=Any iOS Device'
+        run: xcodebuild test -project ../UnitTestApp01.xcodeproj -scheme UnitTestApp01 -destination 'platform=iOS, name=Any iOS Device'
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -12,15 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '14.1.0'
-
       - name: UnitTests
         run: |
           xcodebuild test \
             -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
+            -configuration Debug \
             -destination 'platform=iOS Simulator,name=iPhone 11'
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -22,5 +22,5 @@ jobs:
             -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,OS=16.4,name=iPhone 14' \
+            -destination 'platform=iOS Simulator,os=16.4,name=iPhone 14' \
             -sdk iphonesimulator

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macOS-13
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest
+          xcode-version: '14.3.1'
 
       - uses: muukii/actions-xcode-install-simulator@main
         with:

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -18,6 +18,7 @@ jobs:
             -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 11'
+            -destination 'platform=iOS Simulator' \
+            -sdk iphonesimulator
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -23,5 +23,5 @@ jobs:
             -scheme UnitTestApp01 \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14,os=16.4'
+            -destination 'platform=iOS Simulator,os=16.4,name=iPhone 14'
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,6 +17,6 @@ jobs:
           xcode-version: '14.1.0'
 
       - name: UnitTests
-        run: xcodebuild test -project UnitTestApp01.xcodeproj -scheme UnitTestApp01 -sdk iphonesimulator -destination platform='iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder,name=Any iOS Simulator Device'
+        run: xcodebuild test -project UnitTestApp01.xcodeproj -scheme UnitTestApp01 -sdk iphonesimulator -destination 'platform=iOS Simulator,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder,name=Any iOS Simulator Device'
 
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: muukii/actions-xcode-install-simulator@main
+        with:
+          ios_version: "16.4"
+
       - name: UnitTests
         run: |
           xcodebuild test \

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -22,5 +22,5 @@ jobs:
             -project UnitTestApp01.xcodeproj \
             -scheme UnitTestApp01 \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,os=16.4,name=iPhone 14' \
-            -sdk iphonesimulator
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,OS=16.4,name=iPhone 14'


### PR DESCRIPTION
### やったこと
- macos-latest指定をmacos-13指定に修正
macos-latestだとmacos-12でイメージ作成されるみたいなんですが、それだとなぜかconcreteなシミュレータが用意されないみたいです（すみません原因がわかりませんでした）。Any~~だとテストビルドはできないのでmacos-13指定としました。

- xcodebuildのオプション修正
destinationを 'platform=iOS Simulator,OS=16.4,name=iPhone 14' としています。これは自分のローカルに合わせたのですが、ログを見た感じ他にもいくつか選べるシミュレータはあるみたいです（上述しましたがname=Any iOS~~とかはテストビルドできないので指定しない方がいいですね）。

### その他
すみません、検証のため結構ガチャガチャいじったのでcommit履歴汚いです